### PR TITLE
Implement live domain status check

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,7 +24,15 @@ function DomainItem({ domain, onUpdate }) {
         ) : (
           <>
             <p className="font-semibold">{domain.name}</p>
-            <p className="text-sm text-gray-600">Status: {domain.status}</p>
+            <p className="text-sm text-gray-600 flex items-center">
+              Status:
+              <span
+                className={`ml-1 h-2 w-2 rounded-full ${
+                  domain.status === 'ok' ? 'bg-green-500' : 'bg-red-500'
+                }`}
+              />
+              <span className="ml-1">{domain.status}</span>
+            </p>
             <p className="text-sm text-gray-600">SSL bis: {domain.ssl} ({domain.daysLeft} Tage)</p>
           </>
         )}
@@ -46,11 +54,13 @@ export default function App() {
 
   const fetchStatus = async (name) => {
     try {
-      const res = await fetch('http://localhost:3001/api/status');
-      const data = await res.json();
-      const daysLeft = Math.ceil(
-        (new Date(data.ssl) - new Date()) / (1000 * 60 * 60 * 24)
+      const res = await fetch(
+        `http://localhost:3001/api/status?domain=${encodeURIComponent(name)}`
       );
+      const data = await res.json();
+      const daysLeft = data.ssl
+        ? Math.ceil((new Date(data.ssl) - new Date()) / (1000 * 60 * 60 * 24))
+        : 0;
       return { name, status: data.status, ssl: data.ssl, daysLeft };
     } catch (err) {
       return { name, status: 'error', ssl: 'unbekannt', daysLeft: 0 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,12 +1,38 @@
 const express = require('express');
 const cors = require('cors');
+const axios = require('axios');
+
 const app = express();
 const PORT = 3001;
 
 app.use(cors());
 
-app.get('/api/status', (req, res) => {
-  res.json({ status: 'ok', ssl: '2025-01-01' });
+app.get('/api/status', async (req, res) => {
+  const { domain } = req.query;
+
+  if (!domain) {
+    return res.status(400).json({ error: 'Missing domain parameter' });
+  }
+
+  const check = async (url) => {
+    try {
+      const response = await axios.get(url, { timeout: 5000 });
+      return response.status >= 200 && response.status < 400;
+    } catch (err) {
+      return false;
+    }
+  };
+
+  try {
+    let reachable = await check(`https://${domain}`);
+    if (!reachable) {
+      reachable = await check(`http://${domain}`);
+    }
+
+    res.json({ status: reachable ? 'ok' : 'down', ssl: '2025-01-01' });
+  } catch (err) {
+    res.json({ status: 'down', ssl: 'unbekannt' });
+  }
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- check actual domain availability in backend via axios
- display colored status dots in the frontend
- update status fetching logic

## Testing
- `npm run build` in `client`
- `node index.js` in `server` then `curl http://localhost:3001/api/status?domain=example.com`


------
https://chatgpt.com/codex/tasks/task_e_6869b8e2c6e48327b168789d729dce0d