### PR TITLE
Zeige SSL-Gültigkeit in Dashboard

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,7 +33,19 @@ function DomainItem({ domain, onUpdate }) {
               />
               <span className="ml-1">{domain.status}</span>
             </p>
-            <p className="text-sm text-gray-600">SSL bis: {domain.ssl} ({domain.daysLeft} Tage)</p>
+            <p
+              className={`text-sm ${
+                domain.ssl && domain.ssl !== 'unbekannt'
+                  ? domain.daysLeft < 0
+                    ? 'font-bold text-[#ff0000]'
+                    : domain.daysLeft <= 7
+                    ? 'italic text-[#ff6600]'
+                    : 'text-[#a6a6a6]'
+                  : 'text-gray-600'
+              }`}
+            >
+              SSL bis: {domain.ssl} ({domain.daysLeft} Tage)
+            </p>
           </>
         )}
       </div>
@@ -58,9 +70,10 @@ export default function App() {
         `http://localhost:3001/api/status?domain=${encodeURIComponent(name)}`
       );
       const data = await res.json();
-      const daysLeft = data.ssl
-        ? Math.ceil((new Date(data.ssl) - new Date()) / (1000 * 60 * 60 * 24))
-        : 0;
+      const sslDate = new Date(data.ssl);
+      const daysLeft = isNaN(sslDate)
+        ? 0
+        : Math.ceil((sslDate - new Date()) / (1000 * 60 * 60 * 24));
       return { name, status: data.status, ssl: data.ssl, daysLeft };
     } catch (err) {
       return { name, status: 'error', ssl: 'unbekannt', daysLeft: 0 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const axios = require('axios');
+const tls = require('tls');
 
 const app = express();
 const PORT = 3001;
@@ -23,13 +24,38 @@ app.get('/api/status', async (req, res) => {
     }
   };
 
+  const getSSLCertExpiry = (host) => {
+    return new Promise((resolve) => {
+      const socket = tls.connect(443, host, { servername: host }, () => {
+        const cert = socket.getPeerCertificate();
+        socket.end();
+        if (cert && cert.valid_to) {
+          const date = new Date(cert.valid_to);
+          resolve(date.toISOString().split('T')[0]);
+        } else {
+          resolve(null);
+        }
+      });
+      socket.on('error', () => resolve(null));
+      socket.setTimeout(5000, () => {
+        socket.destroy();
+        resolve(null);
+      });
+    });
+  };
+
   try {
     let reachable = await check(`https://${domain}`);
     if (!reachable) {
       reachable = await check(`http://${domain}`);
     }
 
-    res.json({ status: reachable ? 'ok' : 'down', ssl: '2025-01-01' });
+    const sslDate = await getSSLCertExpiry(domain);
+
+    res.json({
+      status: reachable ? 'ok' : 'down',
+      ssl: sslDate || 'unbekannt',
+    });
   } catch (err) {
     res.json({ status: 'down', ssl: 'unbekannt' });
   }


### PR DESCRIPTION
## Summary
- ermittele Ablaufdatum des SSL-Zertifikats im Backend via `tls`
- berechne verbleibende Tage im Frontend robuster
- zeige Ablaufdatum im Dashboard farblich abgestuft (grau, orange kursiv, rot fett)

## Testing
- `npm run build` in `client`
- `npm start` in `server` *(abgebrochen)*

------
https://chatgpt.com/codex/tasks/task_e_6869c38daef08327a6b7d514504967fc