### PR TITLE
Persist domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ custom-uptime-dashboard/
 - Zeigt Online-/Offline-Status für beliebige Domains
 - Zeigt Ablaufdatum und Resttage des SSL-Zertifikats
 - Hinzufügen neuer Domains per Eingabe
-- Bestehende Domains lassen sich bearbeiten und bleiben lokal gespeichert
+- Bestehende Domains lassen sich bearbeiten und werden serverseitig in `server/data/domains.json` gespeichert
 - Navigation & Footer vorhanden
 
 ## 🧠 Hinweis für Codex

--- a/server/data/domains.json
+++ b/server/data/domains.json
@@ -1,0 +1,1 @@
+["example.com"]


### PR DESCRIPTION
## Summary
- persist entered domains on the server
- load domains from server at startup
- document new persistence behavior in README

## Testing
- `npm --prefix client run build`
- `node server/index.js` (started then terminated)

------
https://chatgpt.com/codex/tasks/task_e_6869c99fa4b0832792f9b3e1e11c350a